### PR TITLE
Slight more informative output format for shortlog.

### DIFF
--- a/bin/git-deploy
+++ b/bin/git-deploy
@@ -866,7 +866,7 @@ while (@actions) {
 
         $subject= "Syncing $prefix to $rollout_tag from $host (replacing $start_tag)";
 
-        my $shortlog_cmd= qq(git rev-list --pretty=short "$start_tag..$rollout_tag") . qq( | git shortlog);
+        my $shortlog_cmd= qq(git shortlog --format='%h %s' $start_tag..$rollout_tag);
         my $diff_cmd= qq(git diff --stat $start_tag..$rollout_tag);
         $body=
               "$subject\n\n"


### PR DESCRIPTION
Hi, I figured it would be nice to include the sha1 in the shortlog output just for copy/pasting purpose:

The result looks like this:

<pre>
Alejandro Lopez (1):
      3e60e7e Update hotfix documentation for template hotfixes

Matt Koscica (1):
      ba85a8e remove vestigial POD

Menno Blom (2):
      8e23fbc require Git::Deploy before calling subs from it
      40ce373 Filter on $prefix-[0-9]+ rather than $prefix

Tom Briggs (2):
      a481acb Adding 'post-abort' hook.
      425bab7 Adding 'post-abort' hook.

Yves Orton (3):
      b2fb778 catch failures in __say and fix an error with how its used
      7e2df68 hopefully fix the admin static counter
      5ee0e4c fix .gitignore

Ævar Arnfjörð Bjarmason (5):
      ceee3e2 Git::Deploy: remove GIT_DEPLOYTOOL_* env variables
      2257a22 Phase Hooks: introduce a new GIT_DEPLOY_PREFIX env variable
      959d0b0 Merge remote-tracking branch 'booking-production/master'
      3912a3b bin/git-deploy: add +x bit and symlink
      7a79c22 bin/git-deploy: fix the library search path
</pre>
