### PR TITLE
Return values from environment for GIT_AUTHOR_*

### DIFF
--- a/lib/Git/Deploy.pm
+++ b/lib/Git/Deploy.pm
@@ -187,6 +187,19 @@ sub _get_config {
     } elsif ( $setting !~ m/\./ )  {
         $setting= "$config_prefix.$setting";
     }
+
+    if ( $setting eq 'user.name' ) {
+        if ( my $name = $ENV{GIT_AUTHOR_NAME} ) {
+            return $name;
+        }
+    }
+
+    if ( $setting eq 'user.email' ) {
+        if ( my $email = $ENV{GIT_AUTHOR_EMAIL} ) {
+            return $email;
+        }
+    }
+
     unless ( exists $config{$setting}{$opts} ) {
         # If we have a $config_file specified and we are looking for a $config_prefix 
         # config item we will want to look first in the config file, and only then look 
@@ -239,6 +252,7 @@ sub _get_config {
             }
         }
     }
+
     return $config{$setting}{$opts};
 }
 


### PR DESCRIPTION
Some Git users, like myself, prefer to manage the username and e-mail address that Git sees in the environment.  `git-deploy` does not currently respect this; it simply complains that `user.name` and `user.email` are not set.  This pull request adds the ability to consult the environment variables for those settings.
