### PR TITLE
Invoke a stable 'git status' command to check for cleanliness.

### DIFF
--- a/lib/Git/Deploy.pm
+++ b/lib/Git/Deploy.pm
@@ -665,7 +665,8 @@ sub check_if_working_dir_is_clean {
     my $status= `git status --porcelain`;
     push_timings("gdt_internal__git_status__end");
     return if !$status;
-    return $status;
+    # Ok, that was fun, now invoke it again to generate human-friendly output.
+    return `git status`;
 }
 
 # make_tag($name,@message);


### PR DESCRIPTION
Git 1.8.0 changed the format of 'git status' from

```
... (working directory clean)
```

to

```
..., working directory clean
```

This kind of harmless modification of prose output happens pretty regularly, and relying on the prose parts to determine the result of a Git command is pretty fragile.

Fortunately, Git folks are aware of this, and provide stable interfaces too. For `git status`, the programmatic interface is `git status --porcelain`, which has a stable (and much simpler) output format, with one line per non-clean file. Empty output indicates a clean tree.

I haven't spent a huge amount of effort finding other places this might bite; with this change git-deploy works (to the best of my testing, which isn't much) on Git 1.8.0.
