### PR TITLE
Convert dist.ini to UTF-8

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,7 +1,7 @@
 name = git-deploy
-author = Ævar Arnfjörð Bjarmason <avarab@gmail.com>, Yves Orton <demerphq@gmail.com>
+author = Ã†var ArnfjÃ¶rÃ° Bjarmason <avarab@gmail.com>, Yves Orton <demerphq@gmail.com>
 license = Perl_5
-copyright_holder = Ævar Arnfjörð Bjarmason, Yves Orton
+copyright_holder = Ã†var ArnfjÃ¶rÃ° Bjarmason, Yves Orton
 copyright_year = 2012
 main_module = bin/git-deploy
 


### PR DESCRIPTION
This merely runs `iconv -f iso-8859-1 -t utf-8` on dist.ini to make dzil
commands work on UTF-8 locales.